### PR TITLE
Don't connect, then check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ This package allows you to __prevent__ these inputs from being processed, easily
 Sample usage can be found in [remotehttp_example_test.go](remotehttp_example_test.go).
 
 
+## Other considerations
 
-# Downsides?
+This wrapper-library only considers the case of `http` and `https` schemas; if you're accepting URIs of your own you should absolutely sanity-check you've not been given something with a `file://`, or `ftp://` prefix (and more!)
 
-The only obvious downside I can see is that we have to actually _establish_ a connection to the remote host, before we know where we went.
+Other things you'll want to consider:
 
-Connecting, then checking, is not ideal but there is no sane alternative.
-
-(Rsolving the hostname of a user-supplied URL, then testing that against a whitelist/blacklist, is not sufficient because the DNS address might change after it has been tested, but before it has been used - i.e. race-condition.)
+* Resource limits such as timeout-handling.
+* Resource limits such as whether to follow redirections, and if so how many.
 
 Steve

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -57,7 +57,7 @@ func _isLocalIP(IP net.IP) error {
 //   that we use the returned IP address explicitly.  This ensures we don't
 //   have a time-of-check-time-of-use-race
 //
-func _checker(dialler *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+func _checker(ctx context.Context, dialler *net.Dialer, network, addr string) (net.Conn, error) {
 
 	// Split the address into host/port
 	host, port, err := net.SplitHostPort(addr)
@@ -139,7 +139,7 @@ func Transport() *http.Transport {
 
 		// Setup the connection helper
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			return (_checker(dialler, ctx, network, addr))
+			return (_checker(ctx, dialler, network, addr))
 		},
 
 		// Setup a simple timeout

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -126,6 +126,7 @@ func Transport() *http.Transport {
 
 	// Setup a timeout in our dialler; though the user could change this.
 	dialler := &net.Dialer{
+		DualStack: true,
 		Timeout:   30 * time.Second,
 		KeepAlive: 30 * time.Second,
 	}

--- a/remotehttp.go
+++ b/remotehttp.go
@@ -1,35 +1,26 @@
-// Package remotehttp is a minor wrapper around a http.Transport which
-// will refuse to fetch local resources.
+// Package remotehttp is a minor wrapper around a http.Transport which will refuse to fetch local resources.
 //
-// This package is specifically designed to avoid security attacks which
-// might result from making HTTP-requests with user-supplied URLs.
+// This package is specifically designed to avoid security attacks which might result from making HTTP-requests with
+// user-supplied URLs.
 //
-// A prime example of this happening would be a web-service which is designed
-// to fetch a document then convert it to PDF.  If the user requests a URL
-// such as `http://localhost/server-status` they would receive a pretty PDF
-// version of private information to which they should not be able to access.
+// A prime example of this happening would be a web-service which is designed to fetch a document then convert it to PDF.
+// If the user requests a URL such as `http://localhost/server-status` they would receive a PDF file of private information
+// which they should not have been able to access.
 //
-// Of course you must make sure that users don't request `file://`,
-// `ftp://` and other resources, but this wrapper will allow you to easily
-// ensure that people cannot access your AWS-metadata store, or any other
-// "internal" resources.
+// Of course you must make sure that users don't request `file://`, `ftp://` and other resources, but this wrapper will
+// allow you to easily ensure that people cannot access your AWS-metadata store, or any other "internal" resources.
 package remotehttp
 
 import (
 	"context"
-	"crypto/tls"
 	"fmt"
 	"net"
 	"net/http"
 	"time"
 )
 
-// _isLocalIP tests whether the IP address to which we've connected
-// is a local one.
-//
-// If the IP is local then an error is returned.
-func _isLocalIP(ip string) error {
-	IP := net.ParseIP(ip)
+// _isLocalIP tests whether the IP address to which we've connected is a local one.
+func _isLocalIP(IP net.IP) error {
 
 	for _, cidr := range []string{
 		"127.0.0.0/8",    // IPv4 loopback
@@ -47,72 +38,113 @@ func _isLocalIP(ip string) error {
 		}
 
 		if block.Contains(IP) {
-			return fmt.Errorf("ip address %s is denied as local", ip)
+			return fmt.Errorf("ip address %s is denied as local", IP)
 		}
 	}
 
 	return nil
 }
 
-// Transport is our exported http.Transport object.
+// _checker is the thing that makes our check.
 //
-// This is the sole interface to this library, and it is
-// designed to automatically deny connections which have
-// been established to "local" resources.
+// This function handles things as you would expect:
 //
-// You may modify the transport as you wish, once you've received
-// it.  However note that the DialContext and DialTLS fields should
-// not be modified, or our protection is removed.
+// * Resolve the target to an IP
+//
+// * If the IP is blacklisted abort
+//
+// * Otherwise update the destination to which we'll connect, such
+//   that we use the returned IP address explicitly.  This ensures we don't
+//   have a time-of-check-time-of-use-race
+//
+func _checker(dialler *net.Dialer, ctx context.Context, network, addr string) (net.Conn, error) {
+
+	// Split the address into host/port
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Resolve the given host to an IP
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, err
+	}
+
+	// Now check the resolved IP against our blacklist
+	//
+	// We'll want to rewrite the target so that we
+	// explicitly connect to this resolved IP too,
+	// rather than using the DNS name - which would
+	// be racy.
+	target := ""
+
+	// For each IP we received
+	for _, ip := range ips {
+
+		// Is it blacklisted?  Then abort
+		err = _isLocalIP(ip)
+		if err != nil {
+			return nil, err
+		}
+
+		// Set the connection-target to the resolved address.
+		if ip.To4() != nil {
+			target = fmt.Sprintf("%s:%s", ip, port)
+		}
+		if ip.To16() != nil && ip.To4() == nil {
+			target = fmt.Sprintf("[%s]:%s", ip, port)
+		}
+	}
+
+	// If the IP was bad we'll have terminated already
+	//
+	// If we got here we found (at least) one valid IP.
+	//
+	// NOTE: We'll essentially use the "last" DNS entry which was
+	// returned, as we update the `target` each time we process
+	// a DNS result.
+	//
+	// So if `example.com` resolves to 1.2.3.4 and 1.2.3.6 we'll
+	// be using the second version.
+	//
+	// TODO: Perhaps randomize results?
+	//
+	// Importantly here we're using `target` to specify the resolved
+	// address we've confirmed is safe.
+	return dialler.DialContext(ctx, network, target)
+}
+
+// Transport returns our wrapped http.Transport object.
+//
+// This function is the sole interface to this library, which is designed to automatically deny connections to
+// "local" resources.
+//
+// You may modify the transport as you wish, once you've received it.  However note that the `DialContext` function should
+// not be changed, or our protection is removed.
 func Transport() *http.Transport {
+
+	// Setup a timeout in our dialler; though the user could change this.
+	dialler := &net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}
+
+	// Create a transport with the suitable handlers.
 	return &http.Transport{
-		Dial: (&net.Dialer{
-			Timeout:   30 * time.Second,
-			KeepAlive: 30 * time.Second,
-		}).Dial,
+
+		// Setup the dialler.
+		Dial: dialler.Dial,
+
+		// Setup the connection helper
 		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
-			// Connect
-			c, err := net.Dial(network, addr)
-			if err != nil {
-				return nil, err
-			}
-
-			// See where we connected to.
-			ip, _, _ := net.SplitHostPort(c.RemoteAddr().String())
-
-			// Make the check
-			err = _isLocalIP(ip)
-			if err != nil {
-				return c, err
-			}
-
-			return c, err
+			return (_checker(dialler, ctx, network, addr))
 		},
-		DialTLS: func(network, addr string) (net.Conn, error) {
 
-			// Connect
-			c, err := tls.Dial(network, addr, &tls.Config{})
-			if err != nil {
-				return nil, err
-			}
+		// Setup a simple timeout
+		TLSHandshakeTimeout: 5 * time.Second,
 
-			// See where we connected to.
-			ip, _, _ := net.SplitHostPort(c.RemoteAddr().String())
-
-			// Make the check
-			err = _isLocalIP(ip)
-			if err != nil {
-				return c, err
-			}
-
-			// Continue
-			err = c.Handshake()
-			if err != nil {
-				return c, err
-			}
-
-			return c, c.Handshake()
-		},
-		TLSHandshakeTimeout:   5 * time.Second,
+		// Setup a simple timeout
 		ResponseHeaderTimeout: 5 * time.Second,
 	}
 }

--- a/remotehttp_example_test.go
+++ b/remotehttp_example_test.go
@@ -3,6 +3,7 @@ package remotehttp
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -29,8 +30,24 @@ func Example() {
 	// Make the (GET) request
 	_, err = netClient.Do(req)
 	if err != nil {
-		fmt.Printf("ERROR:%s\n", err.Error())
+
+		//
+		// Remove "::1" and "127.0.0.1" in our error-message.
+		//
+		// Because we could get two different errors:
+		//
+		//    ip address ::1 is denied as local
+		//    ip address 127.0.0.1 is denied as local
+		//
+		// We want to be stable, and work regardless of what the
+		// local testing-system returns.
+		//
+		out := err.Error()
+		out = strings.ReplaceAll(out, "127.0.0.1 ", "")
+		out = strings.ReplaceAll(out, "::1 ", "")
+
+		fmt.Printf("ERROR:%s\n", out)
 	}
 	// Output:
-	// ERROR:Get "http://localhost/server-status": ip address 127.0.0.1 is denied as local
+	// ERROR:Get "http://localhost/server-status": ip address is denied as local
 }

--- a/remotehttp_test.go
+++ b/remotehttp_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Test fetching remote things we shouldn't is denied.
 func TestLocalURLs(t *testing.T) {
 
 	// Local resources we should never fetch
@@ -35,6 +36,37 @@ func TestLocalURLs(t *testing.T) {
 		_, err = netClient.Do(req)
 		if err == nil {
 			t.Fatalf("Expected error requesting %s - expected to be denied", url)
+		}
+	}
+}
+
+// Test fetching resources that are valid is OK
+func TestRemoteURLs(t *testing.T) {
+
+	// These are random-sites that are fine to access.
+	tests := []string{"http://steve.fi/",
+		"http://example.com",
+		"https://news.bbc.co.uk/",
+	}
+
+	var netClient = &http.Client{
+		Transport: Transport(),
+		Timeout:   5 * time.Second,
+	}
+
+	for _, url := range tests {
+
+		// Prepare
+		req, err := http.NewRequest("GET", url, nil)
+
+		if err != nil {
+			t.Fatalf("Unexpected error requesting %s %s", url, err.Error())
+		}
+
+		// Fetch
+		_, err = netClient.Do(req)
+		if err != nil {
+			t.Fatalf("Didn't expect error; %s - %s", url, err.Error())
 		}
 	}
 }


### PR DESCRIPTION
Instead of connecting to the remote host, then checking
which IP we hit do it the obvious way:

* Resolve the host to IP
* Check the IP
   * If bad reject
   * Otherwise rewrite the destination

This closes #2.